### PR TITLE
Even faster tryJSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baustein",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "build": "rm -rf dist/** && mkdir dist && npm run lint && babel src/baustein.js -o dist/baustein.js",
     "lint": "eslint src",

--- a/src/baustein.js
+++ b/src/baustein.js
@@ -104,9 +104,6 @@ var allEvents = {
     drop: false
 };
 
-var jsonRegex = /^[0-9{["tfn]/;
-var b64json = /^[bedIMONWZ]/;
-
 /**
  * Returns the 'inner' type of `obj`.
  * @param {*} obj
@@ -389,19 +386,20 @@ function parseAttributes(el) {
  * @param {String} value
  * @returns {*}
  */
+const b64startChars = new Set('bedIMONWZ');
+const jsonStartChars = new Set('{[0123456789tfn"');
+
 function tryJSON(value) {
-    if (value.length % 4 === 0 && b64json.test(value)) {
+    if (value.length % 4 === 0 && b64startChars.has(value[0])) {
         try {
             var decode = win.atob(value);
-            if (jsonRegex.test(decode)) {
-                return JSON.parse(decode);
-            }
+            return JSON.parse(decode);
         } catch (er) {
         }
     }
 
     try {
-        if (jsonRegex.test(value)) {
+        if (jsonStartChars.has(value[0])) {
             return JSON.parse(value);
         }
     } catch (er) {


### PR DESCRIPTION
This uses Sets instead of Regexs since we only care
about a single character anyway. It also doesn't
bother checking for JSON twice if it's base64.

The end result if that this is another 2-5x faster
than the previous one and about 20x faster than the original on my sample data.

https://jsperf.com/tryjson/1