### PR TITLE
Fix IE11 bug.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,5 +4,11 @@
         "test": {
             "plugins": ["istanbul"]
         }
-    }
+    },
+    "presets": [[
+        "env", {
+        "targets": {
+            "browsers": ['defaults']
+        }
+    }]]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baustein",
-  "version": "2.0.3",
+  "version": "2.0.6",
   "scripts": {
     "build": "rm -rf dist/** && mkdir dist && npm run lint && babel src/baustein.js -o dist/baustein.js",
     "lint": "eslint src",
@@ -42,6 +42,7 @@
     "babel-core": "6.26.0",
     "babel-plugin-istanbul": "4.1.5",
     "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+    "babel-preset-env": "1.6.1",
     "babel-register": "6.26.0",
     "chai": "3.5.0",
     "eslint": "3.10.2",

--- a/src/baustein.js
+++ b/src/baustein.js
@@ -386,8 +386,8 @@ function parseAttributes(el) {
  * @param {String} value
  * @returns {*}
  */
-const b64startChars = new Set('bedIMONWZ');
-const jsonStartChars = new Set('{[0123456789tfn"');
+const b64startChars = new Set(Array.from('bedIMONWZ'));
+const jsonStartChars = new Set(Array.from('{[0123456789tfn"'));
 
 function tryJSON(value) {
     if (value.length % 4 === 0 && b64startChars.has(value[0])) {


### PR DESCRIPTION
Set doesn't like accepting strings in IE11, so turn it into an array first.